### PR TITLE
Remove token-based authentication in posts API

### DIFF
--- a/backend/src/app/api/posts/route-v2.ts
+++ b/backend/src/app/api/posts/route-v2.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { getToken } from '@auth/core/jwt';
+// import { getToken } from '@auth/core/jwt';
 // import { getSession } from 'next-auth/react';
 import prisma from '@lib/prisma';
 
@@ -19,15 +19,15 @@ export async function handle(req: NextApiRequest, res: NextApiResponse) {
   }
 
   // Token Protection
-  const token = getToken( { req } );
+  // const token = getToken( { req } );
 
   // Session Protection
   // const session = await getSession({ req });
 
   // Verify session exists
-  if (!token) {
-    return res.status( 401 ).json( { error: 'You must be logged in to create posts.' } );
-  }
+  // if (!token) {
+  //   return res.status( 401 ).json( { error: 'You must be logged in to create posts.' } );
+  // }
 
   try {
     const { title, slug, content, authorId } = req.body as PostDataProps;


### PR DESCRIPTION
Commented out token retrieval and validation logic in the posts API route. This change temporarily disables token-based protection, possibly for testing or further development.