### PR TITLE
Update Vercel rewrites in aralsf project

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "rewrites": [
-    {"source": "/backend/", "destination": "https://admin-app.vercel.com/"},
-    {"source": "/backend/:match*", "destination": "https://admin-app.vercel.com/:match*"},
-    {"source": "/frontend", "destination": "https://aralsf.vercel.app/"},
-    {"source": "/frontend/:match*", "destination": "https://aralsf.vercel.app/:match*"}
+    {"source": "/backend/", "destination": "https://aralsf-backend.vercel.app/"},
+    {"source": "/backend/:match*", "destination": "https://aralsf-backend.vercel.app/:match*"},
+    {"source": "/", "destination": "https://aralsf-gaty.vercel.app/"},
+    {"source": "/:match*", "destination": "https://aralsf-gaty.vercel.app/:match*"}
   ]
 }


### PR DESCRIPTION
Revised the backend and frontend URL destinations in the vercel.json file. The backend now points to aralsf-backend.vercel.app, and the main site redirects to aralsf-gaty.vercel.app for both root and wildcard paths.