### PR TITLE
Add 'use client' directive to the product category page

### DIFF
--- a/frontend/src/app/product-category/[slug]/page.tsx
+++ b/frontend/src/app/product-category/[slug]/page.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+'use client';
+import React from 'react';
 
 import { PageHeader } from '@/components/page-header';
 import ProductsFilters from '@/components/products/products-filters';


### PR DESCRIPTION
The 'use client' directive was added to ensure client-side rendering. This change also removes an unnecessary `useEffect` import, cleaning up the code.