### PR TITLE
Add new domain to Next.js image configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,8 @@
 const nextConfig = {
   images: {
     domains: [
-      'aralsf.local'
+      'aralsf.local',
+      'aralsf-backend.code-craft.am'
     ]
   }
 };


### PR DESCRIPTION
Updated the Next.js configuration to include 'aralsf-backend.code-craft.am' in the allowed image domains. This change ensures images from this new domain can be properly loaded and displayed within the application.